### PR TITLE
Update package versions across multiple projects

### DIFF
--- a/EstateReportingAPI.BusinessLogic/EstateReportingAPI.BusinessLogic.csproj
+++ b/EstateReportingAPI.BusinessLogic/EstateReportingAPI.BusinessLogic.csproj
@@ -9,7 +9,7 @@
   <ItemGroup>
     <PackageReference Include="MediatR" Version="12.4.1" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.DynamicLinq" Version="8.3.10" />
-    <PackageReference Include="Shared" Version="2024.11.4" />
+    <PackageReference Include="Shared" Version="2025.1.2" />
     <PackageReference Include="EstateManagement.Database" Version="2024.8.2-build128" />
   </ItemGroup>
 

--- a/EstateReportingAPI.Client/EstateReportingAPI.Client.csproj
+++ b/EstateReportingAPI.Client/EstateReportingAPI.Client.csproj
@@ -7,9 +7,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="ClientProxyBase" Version="2024.11.4" />
+    <PackageReference Include="ClientProxyBase" Version="2025.1.2" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-    <PackageReference Include="Shared.Results" Version="2024.11.4" />
+    <PackageReference Include="Shared.Results" Version="2025.1.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/EstateReportingAPI.IntegrationTests/EstateReportingAPI.IntegrationTests.csproj
+++ b/EstateReportingAPI.IntegrationTests/EstateReportingAPI.IntegrationTests.csproj
@@ -21,12 +21,12 @@
 		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 	  </PackageReference>
     <PackageReference Include="Shouldly" Version="4.2.1" />
-	  <PackageReference Include="Shared" Version="2024.11.4" />
-    <PackageReference Include="Shared.IntegrationTesting" Version="2024.11.4" />
+	  <PackageReference Include="Shared" Version="2025.1.2" />
+    <PackageReference Include="Shared.IntegrationTesting" Version="2025.1.2" />
     <PackageReference Include="Ductus.FluentDocker" Version="2.10.59" />
 	  <PackageReference Include="NLog" Version="5.2.8" />
     <PackageReference Include="NLog.Extensions.Logging" Version="5.3.8" />
-    <PackageReference Include="SecurityService.Client" Version="2024.88.2-build73" />
+    <PackageReference Include="SecurityService.Client" Version="2025.1.1" />
 	  <PackageReference Include="Lamar" Version="13.0.3" />
 	  <PackageReference Include="Lamar.Microsoft.DependencyInjection" Version="13.0.3" />
 

--- a/EstateReportingAPI.IntegrationTests/FactSettlementsControllerTests.cs
+++ b/EstateReportingAPI.IntegrationTests/FactSettlementsControllerTests.cs
@@ -22,6 +22,7 @@ namespace EstateReportingAPI.IntegrationTests {
 
         protected override async Task SetupStandingData() {
             await helper.AddCalendarYear(2024);
+            await helper.AddCalendarYear(2025);
 
             // Estates
             await helper.AddEstate("Test Estate", "Ref1");

--- a/EstateReportingAPI/EstateReportingAPI.csproj
+++ b/EstateReportingAPI/EstateReportingAPI.csproj
@@ -12,7 +12,7 @@
 	  <PackageReference Include="EstateManagement.Database" Version="2024.8.2-build128" />
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.3" />
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.20.0" />
-    <PackageReference Include="Shared.Results" Version="2024.11.4" />
+    <PackageReference Include="Shared.Results" Version="2025.1.2" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
   </ItemGroup>
 
@@ -20,7 +20,7 @@
 		<PackageReference Include="Lamar" Version="13.0.3" />
 		<PackageReference Include="Lamar.Microsoft.DependencyInjection" Version="13.0.3" />
 		<PackageReference Include="NLog.Extensions.Logging" Version="5.3.8" />
-		<PackageReference Include="Shared" Version="2024.11.4" />
+		<PackageReference Include="Shared" Version="2025.1.2" />
 		<PackageReference Include="AspNetCore.HealthChecks.SqlServer" Version="8.0.0" />
 		<PackageReference Include="AspNetCore.HealthChecks.UI" Version="8.0.0" />
 		<PackageReference Include="AspNetCore.HealthChecks.UI.Client" Version="8.0.0" />


### PR DESCRIPTION
Updated the `Shared` package to version `2025.1.2` in `EstateReportingAPI.BusinessLogic.csproj`,
`EstateReportingAPI.Client.csproj`,
`EstateReportingAPI.IntegrationTests.csproj`, and
`EstateReportingAPI.csproj`.

Also updated `ClientProxyBase` and `Shared.Results` to version `2025.1.2` in relevant projects.

In `EstateReportingAPI.IntegrationTests.csproj`,
`Shared.IntegrationTesting` was updated to `2025.1.2`, and `SecurityService.Client` was updated to `2025.1.1`.

These changes reflect an overall upgrade of several package dependencies to their latest versions.