### PR TITLE
Update package references in EstateReportingAPI

### DIFF
--- a/EstateReportingAPI.BusinessLogic/EstateReportingAPI.BusinessLogic.csproj
+++ b/EstateReportingAPI.BusinessLogic/EstateReportingAPI.BusinessLogic.csproj
@@ -9,8 +9,8 @@
   <ItemGroup>
     <PackageReference Include="MediatR" Version="12.5.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.DynamicLinq" Version="9.6.5" />
-    <PackageReference Include="Shared" Version="2025.7.10" />
-    <PackageReference Include="TransactionProcessor.Database" Version="2025.7.2-build189" />
+    <PackageReference Include="Shared" Version="2025.7.13" />
+    <PackageReference Include="TransactionProcessor.Database" Version="2025.7.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/EstateReportingAPI.Client/EstateReportingAPI.Client.csproj
+++ b/EstateReportingAPI.Client/EstateReportingAPI.Client.csproj
@@ -7,9 +7,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="ClientProxyBase" Version="2025.7.10" />
+    <PackageReference Include="ClientProxyBase" Version="2025.7.13" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-    <PackageReference Include="Shared.Results" Version="2025.7.10" />
+    <PackageReference Include="Shared.Results" Version="2025.7.13" />
   </ItemGroup>
 
   <ItemGroup>

--- a/EstateReportingAPI.IntegrationTests/EstateReportingAPI.IntegrationTests.csproj
+++ b/EstateReportingAPI.IntegrationTests/EstateReportingAPI.IntegrationTests.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-	  <PackageReference Include="TransactionProcessor.Database" Version="2025.7.2-build189" />
+	  <PackageReference Include="TransactionProcessor.Database" Version="2025.7.2" />
 	  <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="9.0.5" />
 	  <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.7" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
@@ -21,13 +21,13 @@
 		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 	  </PackageReference>
     <PackageReference Include="Shouldly" Version="4.3.0" />
-	  <PackageReference Include="Shared" Version="2025.7.10" />
-	  <PackageReference Include="Shared.Logger" Version="2025.7.10" />
-    <PackageReference Include="Shared.IntegrationTesting" Version="2025.7.10" />
+	  <PackageReference Include="Shared" Version="2025.7.13" />
+	  <PackageReference Include="Shared.Logger" Version="2025.7.13" />
+    <PackageReference Include="Shared.IntegrationTesting" Version="2025.7.13" />
     <PackageReference Include="Ductus.FluentDocker" Version="2.10.59" />
 	  <PackageReference Include="NLog" Version="5.5.0" />
     <PackageReference Include="NLog.Extensions.Logging" Version="5.5.0" />
-    <PackageReference Include="SecurityService.Client" Version="2025.7.2-build89" />
+    <PackageReference Include="SecurityService.Client" Version="2025.7.2" />
 	  <PackageReference Include="Lamar" Version="15.0.0" />
 	  <PackageReference Include="Lamar.Microsoft.DependencyInjection" Version="15.0.0" />
 

--- a/EstateReportingAPI.Tests/EstateReportingAPI.Tests.csproj
+++ b/EstateReportingAPI.Tests/EstateReportingAPI.Tests.csproj
@@ -19,7 +19,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
     <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="Shouldly" Version="4.3.0" />
-    <PackageReference Include="TransactionProcessor.Database" Version="2025.7.2-build189" />
+    <PackageReference Include="TransactionProcessor.Database" Version="2025.7.2" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.0">
       <PrivateAssets>all</PrivateAssets>

--- a/EstateReportingAPI/EstateReportingAPI.csproj
+++ b/EstateReportingAPI/EstateReportingAPI.csproj
@@ -12,8 +12,8 @@
 	  
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.5" />
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.21.2" />
-    <PackageReference Include="Shared.Results" Version="2025.7.10" />
-    <PackageReference Include="Shared.Results.Web" Version="2025.7.10" />
+    <PackageReference Include="Shared.Results" Version="2025.7.13" />
+    <PackageReference Include="Shared.Results.Web" Version="2025.7.13" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
   </ItemGroup>
 
@@ -21,7 +21,7 @@
 		<PackageReference Include="Lamar" Version="15.0.0" />
 		<PackageReference Include="Lamar.Microsoft.DependencyInjection" Version="15.0.0" />
 		<PackageReference Include="NLog.Extensions.Logging" Version="5.5.0" />
-		<PackageReference Include="Shared" Version="2025.7.10" />
+		<PackageReference Include="Shared" Version="2025.7.13" />
 		<PackageReference Include="AspNetCore.HealthChecks.SqlServer" Version="9.0.0" />
 		<PackageReference Include="AspNetCore.HealthChecks.UI" Version="9.0.0" />
 		<PackageReference Include="AspNetCore.HealthChecks.UI.Client" Version="9.0.0" />
@@ -36,7 +36,7 @@
 		<PackageReference Include="Swashbuckle.AspNetCore.SwaggerGen" Version="8.1.4" />
 		<PackageReference Include="Swashbuckle.AspNetCore.SwaggerUI" Version="8.1.4" />
 		<PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="9.0.5" />
-		<PackageReference Include="TransactionProcessor.Database" Version="2025.7.2-build189" />
+		<PackageReference Include="TransactionProcessor.Database" Version="2025.7.2" />
 	</ItemGroup>
 
 	<ItemGroup>


### PR DESCRIPTION
Updated several package versions in the project files for `EstateReportingAPI`, including `Shared`, `TransactionProcessor.Database`, `ClientProxyBase`, `Shared.Results`, `Shared.Logger`, `Shared.IntegrationTesting`, and `SecurityService.Client` from `2025.7.10` to `2025.7.13`. The version of `TransactionProcessor.Database` was also changed from `2025.7.2-build189` to `2025.7.2`. These updates may include bug fixes, performance improvements, or new features.

closes #134 