### PR TITLE
Handle empty query results with non-null response

### DIFF
--- a/EstateReportingAPI.BusinessLogic/ReportingManager.cs
+++ b/EstateReportingAPI.BusinessLogic/ReportingManager.cs
@@ -651,7 +651,11 @@ public class ReportingManager : IReportingManager {
         // Ok now enumerate the results
         var queryResults = await query.ToListAsync(cancellationToken);
         if (queryResults.Any() == false)
-            return response;
+            return new TransactionDetailReportResponse
+            {
+                Summary = new TransactionDetailSummary(),
+                Transactions = new List<TransactionDetail>()
+            };
         
         // Now to translate the results
         response = new TransactionDetailReportResponse {


### PR DESCRIPTION
Previously, the method could return a null or uninitialized response when no query results were found. Now, it always returns a valid TransactionDetailReportResponse with empty Summary and Transactions, ensuring consistent and non-null responses.

closes #406 