### PR TITLE
Refactor to use Result<T> pattern for queries and handlers

### DIFF
--- a/EstateReportingAPI.BusinessLogic/EstateReportingAPI.BusinessLogic.csproj
+++ b/EstateReportingAPI.BusinessLogic/EstateReportingAPI.BusinessLogic.csproj
@@ -9,7 +9,8 @@
   <ItemGroup>
     <PackageReference Include="MediatR" Version="14.0.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.DynamicLinq" Version="10.7.1" />
-    <PackageReference Include="Shared" Version="2025.12.2" />
+    <PackageReference Include="Shared" Version="2026.2.1" />
+    <PackageReference Include="Shared.Results" Version="2026.2.1" />
     <PackageReference Include="TransactionProcessor.Database" Version="2025.12.2-build270" />
   </ItemGroup>
 

--- a/EstateReportingAPI.BusinessLogic/ReportingManager.cs
+++ b/EstateReportingAPI.BusinessLogic/ReportingManager.cs
@@ -763,7 +763,7 @@ public class ReportingManager : IReportingManager {
         return Result.Success(@operator);
     }
 
-    public async Task<Result<TransactionDetailReportResponse> GetTransactionDetailReport(TransactionQueries.TransactionDetailReportQuery request,
+    public async Task<Result<TransactionDetailReportResponse>> GetTransactionDetailReport(TransactionQueries.TransactionDetailReportQuery request,
                                                                                   CancellationToken cancellationToken) {
 
         TransactionDetailReportResponse response = null;

--- a/EstateReportingAPI.BusinessLogic/RequestHandlers/CalendarRequestHandler.cs
+++ b/EstateReportingAPI.BusinessLogic/RequestHandlers/CalendarRequestHandler.cs
@@ -1,6 +1,7 @@
 ﻿using EstateReportingAPI.BusinessLogic.Queries;
 using EstateReportingAPI.Models;
 using MediatR;
+using Shared.Results;
 using SimpleResults;
 
 namespace EstateReportingAPI.BusinessLogic.RequestHandlers;
@@ -13,35 +14,21 @@ public class CalendarRequestHandler : IRequestHandler<CalendarQueries.GetAllDate
         }
         public async Task<Result<List<Calendar>>> Handle(CalendarQueries.GetAllDatesQuery request,
                                                          CancellationToken cancellationToken) {
-            List<Calendar> result = await this.Manager.GetCalendarDates(request, cancellationToken);
-
-            if (result.Any() == false) {
-                return Result.NotFound("No calendar dates found");
-            }
-
-            return Result.Success(result);
-
+            return await this.Manager.GetCalendarDates(request, cancellationToken);
         }
 
         public async Task<Result<List<Calendar>>> Handle(CalendarQueries.GetComparisonDatesQuery request,
                                                          CancellationToken cancellationToken) {
-            List<Calendar> result = await this.Manager.GetCalendarComparisonDates(request, cancellationToken);
-            if (result.Any() == false)
-            {
-                return Result.NotFound("No calendar comparison dates found");
-            }
+            Result<List<Calendar>> result = await this.Manager.GetCalendarComparisonDates(request, cancellationToken);
 
-            return Result.Success(result);
+            if (result.IsFailed)
+                return ResultHelpers.CreateFailure(result);
+
+            return Result.Success(result.Data);
         }
 
         public async Task<Result<List<Int32>>> Handle(CalendarQueries.GetYearsQuery request,
                                                       CancellationToken cancellationToken) {
-            List<Int32> result = await this.Manager.GetCalendarYears(request, cancellationToken);
-            if (result.Any() == false)
-            {
-                return Result.NotFound("No calendar years found");
-            }
-
-            return Result.Success(result);
+            return await this.Manager.GetCalendarYears(request, cancellationToken);
         }
     }

--- a/EstateReportingAPI.BusinessLogic/RequestHandlers/ContractRequestHandler.cs
+++ b/EstateReportingAPI.BusinessLogic/RequestHandlers/ContractRequestHandler.cs
@@ -18,21 +18,19 @@ public class ContractRequestHandler : IRequestHandler<ContractQueries.GetRecentC
     }
     public async Task<Result<List<Contract>>> Handle(ContractQueries.GetRecentContractsQuery request,
                                                      CancellationToken cancellationToken) {
-        var result = await this.Manager.GetRecentContracts(request, cancellationToken);
-        return Result.Success(result);
+        return await this.Manager.GetRecentContracts(request, cancellationToken);
     }
 
     public async Task<Result<List<Contract>>> Handle(ContractQueries.GetContractsQuery request,
                                                      CancellationToken cancellationToken)
     {
         var result = await this.Manager.GetContracts(request, cancellationToken);
-        return Result.Success(result);
+        return result;
     }
 
     public async Task<Result<Contract>> Handle(ContractQueries.GetContractQuery request,
                                                CancellationToken cancellationToken)
     {
-        var result = await this.Manager.GetContract(request, cancellationToken);
-        return Result.Success(result);
+        return await this.Manager.GetContract(request, cancellationToken);
     }
 }

--- a/EstateReportingAPI.BusinessLogic/RequestHandlers/EstateRequestHandler.cs
+++ b/EstateReportingAPI.BusinessLogic/RequestHandlers/EstateRequestHandler.cs
@@ -18,13 +18,11 @@ public class EstateRequestHandler : IRequestHandler<EstateQueries.GetEstateQuery
     public async Task<Result<Estate>> Handle(EstateQueries.GetEstateQuery request,
                                              CancellationToken cancellationToken)
     {
-        var result = await this.Manager.GetEstate(request, cancellationToken);
-        return Result.Success(result);
+        return await this.Manager.GetEstate(request, cancellationToken);
     }
 
     public async Task<Result<List<EstateOperator>>> Handle(EstateQueries.GetEstateOperatorsQuery request,
                                                            CancellationToken cancellationToken) {
-        var result = await this.Manager.GetEstateOperators(request, cancellationToken);
-        return Result.Success(result);
+        return await this.Manager.GetEstateOperators(request, cancellationToken);
     }
 }

--- a/EstateReportingAPI.BusinessLogic/RequestHandlers/MerchantRequestHandler.cs
+++ b/EstateReportingAPI.BusinessLogic/RequestHandlers/MerchantRequestHandler.cs
@@ -21,47 +21,36 @@ public class MerchantRequestHandler : IRequestHandler<MerchantQueries.GetRecentM
         
     public async Task<Result<List<Merchant>>> Handle(MerchantQueries.GetRecentMerchantsQuery request,
                                                      CancellationToken cancellationToken) {
-        var result = await this.Manager.GetRecentMerchants(request, cancellationToken);
-        return Result.Success(result);
+        return await this.Manager.GetRecentMerchants(request, cancellationToken);
     }
     public async Task<Result<MerchantKpi>> Handle(MerchantQueries.GetTransactionKpisQuery request,
                                                   CancellationToken cancellationToken)
     {
-        var result = await this.Manager.GetMerchantsTransactionKpis(request, cancellationToken);
-        return Result.Success(result);
+        return await this.Manager.GetMerchantsTransactionKpis(request, cancellationToken);
     }
 
     public async Task<Result<List<Merchant>>> Handle(MerchantQueries.GetMerchantsQuery request,
                                                      CancellationToken cancellationToken) {
-        var result = await this.Manager.GetMerchants(request, cancellationToken);
-        return Result.Success(result);
+        return await this.Manager.GetMerchants(request, cancellationToken);
     }
 
     public async Task<Result<Merchant>> Handle(MerchantQueries.GetMerchantQuery request,
                                                CancellationToken cancellationToken) {
-        var result = await this.Manager.GetMerchant(request, cancellationToken);
-
-        if (result == null)
-            return Result.NotFound();
-
-        return Result.Success(result);
+        return await this.Manager.GetMerchant(request, cancellationToken);
     }
 
     public async Task<Result<List<MerchantContract>>> Handle(MerchantQueries.GetMerchantContractsQuery request,
                                                              CancellationToken cancellationToken) {
-        var result = await this.Manager.GetMerchantContracts(request, cancellationToken);
-        return Result.Success(result);
+        return await this.Manager.GetMerchantContracts(request, cancellationToken);
     }
 
     public async Task<Result<List<MerchantOperator>>> Handle(MerchantQueries.GetMerchantOperatorsQuery request,
                                                              CancellationToken cancellationToken) {
-        var result = await this.Manager.GetMerchantOperators(request, cancellationToken);
-        return Result.Success(result);
+        return await this.Manager.GetMerchantOperators(request, cancellationToken);
     }
 
     public async Task<Result<List<MerchantDevice>>> Handle(MerchantQueries.GetMerchantDevicesQuery request,
                                                            CancellationToken cancellationToken) {
-        var result = await this.Manager.GetMerchantDevices(request, cancellationToken);
-        return Result.Success(result);
+        return await this.Manager.GetMerchantDevices(request, cancellationToken);
     }
 }

--- a/EstateReportingAPI.BusinessLogic/RequestHandlers/OperatorRequestHandler.cs
+++ b/EstateReportingAPI.BusinessLogic/RequestHandlers/OperatorRequestHandler.cs
@@ -17,13 +17,11 @@ public class OperatorRequestHandler : IRequestHandler<OperatorQueries.GetOperato
 
     public async Task<Result<List<Operator>>> Handle(OperatorQueries.GetOperatorsQuery request,
                                                      CancellationToken cancellationToken) {
-        List<Operator> result = await this.Manager.GetOperators(request, cancellationToken);
-        return Result.Success(result);
+        return await this.Manager.GetOperators(request, cancellationToken);
     }
 
     public async Task<Result<Operator>> Handle(OperatorQueries.GetOperatorQuery request,
                                                CancellationToken cancellationToken) {
-        Operator result = await this.Manager.GetOperator(request, cancellationToken);
-        return Result.Success(result);
+        return await this.Manager.GetOperator(request, cancellationToken);
     }
 }

--- a/EstateReportingAPI.BusinessLogic/RequestHandlers/TransactionRequestHandler.cs
+++ b/EstateReportingAPI.BusinessLogic/RequestHandlers/TransactionRequestHandler.cs
@@ -26,7 +26,6 @@ IRequestHandler<TransactionQueries.TransactionDetailReportQuery, Result<Transact
 
     public async Task<Result<TransactionDetailReportResponse>> Handle(TransactionQueries.TransactionDetailReportQuery request,
                                                                       CancellationToken cancellationToken) {
-        var result = await this.Manager.GetTransactionDetailReport(request, cancellationToken);
-        return Result.Success(result);
+        return await this.Manager.GetTransactionDetailReport(request, cancellationToken);
     }
 }

--- a/EstateReportingAPI.BusinessLogic/RequestHandlers/TransactionRequestHandler.cs
+++ b/EstateReportingAPI.BusinessLogic/RequestHandlers/TransactionRequestHandler.cs
@@ -16,14 +16,12 @@ IRequestHandler<TransactionQueries.TransactionDetailReportQuery, Result<Transact
 
     public async Task<Result<TodaysSales>> Handle(TransactionQueries.TodaysFailedSales request,
                                                   CancellationToken cancellationToken) {
-        var result = await this.Manager.GetTodaysFailedSales(request, cancellationToken);
-        return Result.Success(result);
+        return await this.Manager.GetTodaysFailedSales(request, cancellationToken);
     }
 
     public async Task<Result<TodaysSales>> Handle(TransactionQueries.TodaysSalesQuery request,
                                                   CancellationToken cancellationToken) {
-        var result = await this.Manager.GetTodaysSales(request, cancellationToken);
-        return Result.Success(result);
+        return await this.Manager.GetTodaysSales(request, cancellationToken);
     }
 
     public async Task<Result<TransactionDetailReportResponse>> Handle(TransactionQueries.TransactionDetailReportQuery request,

--- a/EstateReportingAPI.Client/EstateReportingAPI.Client.csproj
+++ b/EstateReportingAPI.Client/EstateReportingAPI.Client.csproj
@@ -7,9 +7,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="ClientProxyBase" Version="2025.12.2" />
+    <PackageReference Include="ClientProxyBase" Version="2026.2.1" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
-    <PackageReference Include="Shared.Results" Version="2025.12.2" />
+    <PackageReference Include="Shared.Results" Version="2026.2.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/EstateReportingAPI.IntegrationTests/EstateReportingAPI.IntegrationTests.csproj
+++ b/EstateReportingAPI.IntegrationTests/EstateReportingAPI.IntegrationTests.csproj
@@ -22,9 +22,9 @@
 		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 	  </PackageReference>
     <PackageReference Include="Shouldly" Version="4.3.0" />
-	  <PackageReference Include="Shared" Version="2025.12.2" />
-	  <PackageReference Include="Shared.Logger" Version="2025.12.2" />
-    <PackageReference Include="Shared.IntegrationTesting" Version="2025.12.2" />
+	  <PackageReference Include="Shared" Version="2026.2.1" />
+	  <PackageReference Include="Shared.Logger" Version="2026.2.1" />
+    <PackageReference Include="Shared.IntegrationTesting" Version="2026.2.1" />
     <PackageReference Include="Ductus.FluentDocker" Version="2.85.0" />
 	  <PackageReference Include="NLog" Version="6.0.7" />
     <PackageReference Include="NLog.Extensions.Logging" Version="6.1.0" />

--- a/EstateReportingAPI/EstateReportingAPI.csproj
+++ b/EstateReportingAPI/EstateReportingAPI.csproj
@@ -12,8 +12,8 @@
 	  
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.1" />
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.22.1" />
-    <PackageReference Include="Shared.Results" Version="2025.12.2" />
-    <PackageReference Include="Shared.Results.Web" Version="2025.12.2" />
+    <PackageReference Include="Shared.Results" Version="2026.2.1" />
+    <PackageReference Include="Shared.Results.Web" Version="2026.2.1" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="10.0.1" />
   </ItemGroup>
 
@@ -21,7 +21,7 @@
 		<PackageReference Include="Lamar" Version="15.0.1" />
 		<PackageReference Include="Lamar.Microsoft.DependencyInjection" Version="15.0.1" />
 		<PackageReference Include="NLog.Extensions.Logging" Version="6.1.0" />
-		<PackageReference Include="Shared" Version="2025.12.2" />
+		<PackageReference Include="Shared" Version="2026.2.1" />
 		<PackageReference Include="AspNetCore.HealthChecks.SqlServer" Version="9.0.0" />
 		<PackageReference Include="AspNetCore.HealthChecks.UI.Client" Version="9.0.0" />
 		<PackageReference Include="AspNetCore.HealthChecks.UI.InMemory.Storage" Version="9.0.0" />


### PR DESCRIPTION
Standardized all business logic and request handler methods to return Result<T> for consistent error and not-found handling. Introduced helper methods in ReportingManager for safe query execution. Updated all MediatR handlers to propagate Result<T> directly. Upgraded Shared, Shared.Results, and related NuGet packages to 2026.2.1. Improved error handling, code consistency, and maintainability across the API.

closes #407 