### PR TITLE
Add Transaction Summary By Operator report and endpoint

### DIFF
--- a/EstateReportingAPI.BusinessLogic/Queries/TransactionQueries.cs
+++ b/EstateReportingAPI.BusinessLogic/Queries/TransactionQueries.cs
@@ -10,7 +10,7 @@ public record TransactionQueries {
     public record TodaysSalesQuery(Guid EstateId, Int32 MerchantReportingId, Int32 OperatorReportingId, DateTime ComparisonDate) : IRequest<Result<TodaysSales>>;
     public record TodaysFailedSales(Guid EstateId, DateTime ComparisonDate, String ResponseCode) : IRequest<Result<TodaysSales>>;
     public record TransactionDetailReportQuery(Guid EstateId, TransactionDetailReportRequest Request) : IRequest<Result<TransactionDetailReportResponse>>;
-
     public record TransactionSummaryByMerchantQuery(Guid EstateId, TransactionSummaryByMerchantRequest Request) : IRequest<Result<TransactionSummaryByMerchantResponse>>;
-    
+    public record TransactionSummaryByOperatorQuery(Guid EstateId, TransactionSummaryByOperatorRequest Request) : IRequest<Result<TransactionSummaryByOperatorResponse>>;
+
 }

--- a/EstateReportingAPI.BusinessLogic/ReportingManager.cs
+++ b/EstateReportingAPI.BusinessLogic/ReportingManager.cs
@@ -1041,7 +1041,9 @@ public class ReportingManager : IReportingManager {
                 AddressLine1 = queryResult.Address.AddressLine1,
                 AddressLine2 = queryResult.Address.AddressLine2,
                 Town = queryResult.Address.Town,
-                Country = queryResult.Address.Country
+                Country = queryResult.Address.Country,
+                MerchantReportingId = queryResult.Merchant.MerchantReportingId
+                
             });
         }
 

--- a/EstateReportingAPI.BusinessLogic/ReportingManager.cs
+++ b/EstateReportingAPI.BusinessLogic/ReportingManager.cs
@@ -46,6 +46,9 @@ public interface IReportingManager
                                                                     CancellationToken cancellationToken);
     Task<Result<TransactionSummaryByMerchantResponse>> GetTransactionSummaryByMerchantReport(TransactionQueries.TransactionSummaryByMerchantQuery request,
                                                                              CancellationToken cancellationToken);
+    
+    Task<Result<TransactionSummaryByOperatorResponse>> GetTransactionSummaryByOperatorReport(TransactionQueries.TransactionSummaryByOperatorQuery request,
+                                                                                 CancellationToken cancellationToken);
 
     #endregion
 }
@@ -968,6 +971,117 @@ public class ReportingManager : IReportingManager {
                 AverageValue = this.SafeDivide(queryResults.Sum(q => q.TotalValue)
                                                ,queryResults.Sum(q => q.TotalCount)),
                 TotalMerchants = queryResults.Count()
+            }
+        };
+
+        return response;
+    }
+
+    public async Task<Result<TransactionSummaryByOperatorResponse>> GetTransactionSummaryByOperatorReport(TransactionQueries.TransactionSummaryByOperatorQuery request,
+                                                                                                          CancellationToken cancellationToken) {
+        TransactionSummaryByOperatorResponse response = null;
+        using ResolvedDbContext<EstateManagementContext>? resolvedContext = this.Resolver.Resolve(EstateManagementDatabaseName, request.EstateId.ToString());
+        await using EstateManagementContext context = resolvedContext.Context;
+
+        var query =
+            from t in context.Transactions
+            join m in context.Merchants on t.MerchantId equals m.MerchantId
+            join o in context.Operators on t.OperatorId equals o.OperatorId
+            where t.TransactionType == "Sale"
+                  && t.TransactionDate >= request.Request.StartDate
+                  && t.TransactionDate <= request.Request.EndDate
+            group t by new
+            {
+                t.MerchantId,
+                m.MerchantReportingId,
+                MerchantName = m.Name,
+                t.OperatorId,
+                o.OperatorReportingId,
+                OperatorName = o.Name
+            }
+            into g
+            select new
+            {
+                g.Key.MerchantId,
+                g.Key.MerchantReportingId,
+                g.Key.MerchantName,
+                g.Key.OperatorId,
+                g.Key.OperatorReportingId,
+                g.Key.OperatorName,
+                TotalCount = g.Count(),
+                TotalValue = g.Sum(x => x.TransactionAmount),
+                AuthorisedCount = g.Sum(x => x.IsAuthorised ? 1 : 0),
+                DeclinedCount = g.Sum(x => x.IsAuthorised ? 0 : 1)
+            };
+
+        // Now apply the filters
+        if (request.Request.Merchants != null && request.Request.Merchants.Any())
+        {
+            query = query.Where(q => request.Request.Merchants.Contains(q.MerchantReportingId));
+        }
+        if (request.Request.Operators != null && request.Request.Operators.Any())
+        {
+            query = query.Where(q => request.Request.Operators.Contains(q.OperatorReportingId));
+        }
+
+        var finalQuery = from x in query
+                         group x by new
+                         {
+                             x.OperatorId,
+                             x.OperatorReportingId,
+                             OperatorName = x.OperatorName,
+                         }
+            into g
+                         select new
+                         {
+                             g.Key.OperatorId,
+                             g.Key.OperatorReportingId,
+                             g.Key.OperatorName,
+                             TotalCount = g.Sum(x => x.TotalCount),
+                             TotalValue = g.Sum(x => x.TotalValue),
+                             AverageValue = g.Count() > 0 ? g.Sum(x => x.TotalValue) / g.Count() : 0m,
+                             AuthorisedCount = g.Sum(x => x.AuthorisedCount),
+                             DeclinedCount = g.Sum(x => x.DeclinedCount),
+                             AuthorisedPercentage = g.Sum(x => x.TotalCount) > 0 ? (decimal)g.Sum(x => x.AuthorisedCount) / (decimal)g.Sum(x => x.TotalCount) : 0m
+                         };
+
+        var queryResult = await ExecuteQuerySafeToList(finalQuery, cancellationToken, "Error retrieving transaction summary by operator report");
+
+        if (queryResult.IsFailed)
+            return ResultHelpers.CreateFailure(queryResult);
+
+        // Ok now enumerate the results
+        var queryResults = queryResult.Data;
+
+        if (queryResults.Any() == false)
+            return new TransactionSummaryByOperatorResponse
+            {
+                Summary = new OperatorDetailSummary(),
+                Operators = new List<OperatorDetail>()
+            };
+
+        // Now to translate the results
+        response = new TransactionSummaryByOperatorResponse
+        {
+            Operators = queryResults.Select(q => new OperatorDetail
+            {
+                OperatorId = q.OperatorId,
+                OperatorReportingId = q.OperatorReportingId,
+                OperatorName = q.OperatorName,
+                AuthorisedCount = q.AuthorisedCount,
+                AuthorisedPercentage = q.AuthorisedPercentage,
+                AverageValue = q.AverageValue,
+                DeclinedCount = q.DeclinedCount,
+                TotalCount = q.TotalCount,
+                TotalValue = q.TotalValue
+            }).ToList(),
+            Summary = new OperatorDetailSummary
+            {
+                TotalCount = queryResults.Sum(q => q.TotalCount),
+                TotalValue = queryResults.Sum(q => q.TotalValue),
+                AverageValue = this.SafeDivide(queryResults.Sum(q => q.TotalValue)
+                                               , queryResults.Sum(q => q.TotalCount)),
+                TotalOperators = queryResults.Count()
             }
         };
 

--- a/EstateReportingAPI.BusinessLogic/RequestHandlers/TransactionRequestHandler.cs
+++ b/EstateReportingAPI.BusinessLogic/RequestHandlers/TransactionRequestHandler.cs
@@ -7,8 +7,9 @@ namespace EstateReportingAPI.BusinessLogic.RequestHandlers;
 
 public class TransactionRequestHandler : IRequestHandler<TransactionQueries.TodaysFailedSales, Result<TodaysSales>>,
     IRequestHandler<TransactionQueries.TodaysSalesQuery, Result<TodaysSales>>,
-IRequestHandler<TransactionQueries.TransactionDetailReportQuery, Result<TransactionDetailReportResponse>>,
-    IRequestHandler<TransactionQueries.TransactionSummaryByMerchantQuery, Result<TransactionSummaryByMerchantResponse>>
+    IRequestHandler<TransactionQueries.TransactionDetailReportQuery, Result<TransactionDetailReportResponse>>,
+    IRequestHandler<TransactionQueries.TransactionSummaryByMerchantQuery, Result<TransactionSummaryByMerchantResponse>>,
+    IRequestHandler<TransactionQueries.TransactionSummaryByOperatorQuery, Result<TransactionSummaryByOperatorResponse>>
 {
     private readonly IReportingManager Manager;
 
@@ -35,5 +36,11 @@ IRequestHandler<TransactionQueries.TransactionDetailReportQuery, Result<Transact
                                                                       CancellationToken cancellationToken)
     {
         return await this.Manager.GetTransactionSummaryByMerchantReport(request, cancellationToken);
+    }
+
+    public async Task<Result<TransactionSummaryByOperatorResponse>> Handle(TransactionQueries.TransactionSummaryByOperatorQuery request,
+                                                                      CancellationToken cancellationToken)
+    {
+        return await this.Manager.GetTransactionSummaryByOperatorReport(request, cancellationToken);
     }
 }

--- a/EstateReportingAPI.DataTrasferObjects/TransactionDetailReportResponse.cs
+++ b/EstateReportingAPI.DataTrasferObjects/TransactionDetailReportResponse.cs
@@ -51,3 +51,46 @@ public class MerchantDetailSummary {
     [JsonProperty("average_value")]
     public Decimal AverageValue { get; set; }
 }
+
+
+public class TransactionSummaryByOperatorResponse
+{
+    [JsonProperty("operators")]
+    public List<OperatorDetail> Operators { get; set; }
+    [JsonProperty("summary")]
+    public OperatorDetailSummary Summary { get; set; }
+}
+
+public class OperatorDetail
+{
+    [JsonProperty("operator_id")]
+    public Guid OperatorId { get; set; }
+    [JsonProperty("operator_reporting_id")]
+    public Int32 OperatorReportingId { get; set; }
+    [JsonProperty("operator_name")]
+    public string OperatorName { get; set; }
+    [JsonProperty("total_count")]
+    public Int32 TotalCount { get; set; }
+    [JsonProperty("total_value")]
+    public Decimal TotalValue { get; set; }
+    [JsonProperty("average_value")]
+    public Decimal AverageValue { get; set; }
+    [JsonProperty("authorised_count")]
+    public Int32 AuthorisedCount { get; set; }
+    [JsonProperty("declined_count")]
+    public Int32 DeclinedCount { get; set; }
+    [JsonProperty("authorised_percentage")]
+    public Decimal AuthorisedPercentage { get; set; }
+}
+
+public class OperatorDetailSummary
+{
+    [JsonProperty("total_operators")]
+    public Int32 TotalOperators { get; set; }
+    [JsonProperty("total_count")]
+    public Int32 TotalCount { get; set; }
+    [JsonProperty("total_value")]
+    public Decimal TotalValue { get; set; }
+    [JsonProperty("average_value")]
+    public Decimal AverageValue { get; set; }
+}

--- a/EstateReportingAPI.DataTrasferObjects/TransactionSummaryByMerchantRequest.cs
+++ b/EstateReportingAPI.DataTrasferObjects/TransactionSummaryByMerchantRequest.cs
@@ -4,14 +4,12 @@ using Newtonsoft.Json;
 
 namespace EstateReportingAPI.DataTransferObjects;
 
-public class TransactionDetailReportRequest
+public class TransactionSummaryByMerchantRequest
 {
     [JsonProperty("operators")]
     public List<Int32>? Operators { get; set; }
     [JsonProperty("merchants")]
     public List<Int32>? Merchants { get; set; }
-    [JsonProperty("products")]
-    public List<Int32>? Products { get; set; }
     [JsonProperty("start_date")]
     public DateTime StartDate { get; set; }
     [JsonProperty("end_date")]

--- a/EstateReportingAPI.DataTrasferObjects/TransactionSummaryByOperatorRequest.cs
+++ b/EstateReportingAPI.DataTrasferObjects/TransactionSummaryByOperatorRequest.cs
@@ -4,14 +4,12 @@ using Newtonsoft.Json;
 
 namespace EstateReportingAPI.DataTransferObjects;
 
-public class TransactionDetailReportRequest
+public class TransactionSummaryByOperatorRequest
 {
     [JsonProperty("operators")]
     public List<Int32>? Operators { get; set; }
     [JsonProperty("merchants")]
     public List<Int32>? Merchants { get; set; }
-    [JsonProperty("products")]
-    public List<Int32>? Products { get; set; }
     [JsonProperty("start_date")]
     public DateTime StartDate { get; set; }
     [JsonProperty("end_date")]

--- a/EstateReportingAPI.Models/MerchantDetail.cs
+++ b/EstateReportingAPI.Models/MerchantDetail.cs
@@ -1,0 +1,27 @@
+﻿namespace EstateReportingAPI.Models;
+
+public class MerchantDetail
+{
+    public Guid MerchantId { get; set; }
+    public Int32 MerchantReportingId { get; set; }
+    public string MerchantName { get; set; }
+    public Int32 TotalCount { get; set; }
+    public Decimal TotalValue { get; set; }
+    public Decimal AverageValue { get; set; }
+    public Int32 AuthorisedCount { get; set; }
+    public Int32 DeclinedCount { get; set; }
+    public Decimal AuthorisedPercentage { get; set; }
+}
+
+public class OperatorDetail
+{
+    public Guid OperatorId { get; set; }
+    public Int32 OperatorReportingId { get; set; }
+    public string OperatorName { get; set; }
+    public Int32 TotalCount { get; set; }
+    public Decimal TotalValue { get; set; }
+    public Decimal AverageValue { get; set; }
+    public Int32 AuthorisedCount { get; set; }
+    public Int32 DeclinedCount { get; set; }
+    public Decimal AuthorisedPercentage { get; set; }
+}

--- a/EstateReportingAPI.Models/MerchantDetailSummary.cs
+++ b/EstateReportingAPI.Models/MerchantDetailSummary.cs
@@ -1,0 +1,9 @@
+﻿namespace EstateReportingAPI.Models;
+
+public class MerchantDetailSummary
+{
+    public Int32 TotalMerchants { get; set; }
+    public Int32 TotalCount { get; set; }
+    public Decimal TotalValue { get; set; }
+    public Decimal AverageValue { get; set; }
+}

--- a/EstateReportingAPI.Models/OperatorDetailSummary.cs
+++ b/EstateReportingAPI.Models/OperatorDetailSummary.cs
@@ -1,0 +1,9 @@
+﻿namespace EstateReportingAPI.Models;
+
+public class OperatorDetailSummary
+{
+    public Int32 TotalOperators { get; set; }
+    public Int32 TotalCount { get; set; }
+    public Decimal TotalValue { get; set; }
+    public Decimal AverageValue { get; set; }
+}

--- a/EstateReportingAPI.Models/TransactionDetail.cs
+++ b/EstateReportingAPI.Models/TransactionDetail.cs
@@ -1,0 +1,20 @@
+﻿namespace EstateReportingAPI.Models;
+
+public class TransactionDetail {
+    public Guid Id { get; set; }
+    public DateTime DateTime { get; set; }
+    public String Merchant { get; set; }
+    public Guid MerchantId { get; set; }
+    public Int32 MerchantReportingId { get; set; }
+    public String Operator { get; set; }
+    public Guid OperatorId { get; set; }
+    public Int32 OperatorReportingId { get; set; }
+    public String Product { get; set; }
+    public Guid ProductId { get; set; }
+    public Int32 ProductReportingId { get; set; }
+    public String Type { get; set; }
+    public String Status { get; set; }
+    public Decimal Value { get; set; }
+    public Decimal TotalFees { get; set; }
+    public String SettlementReference { get; set; }
+}

--- a/EstateReportingAPI.Models/TransactionDetailReportResponse.cs
+++ b/EstateReportingAPI.Models/TransactionDetailReportResponse.cs
@@ -1,0 +1,6 @@
+﻿namespace EstateReportingAPI.Models;
+
+public class TransactionDetailReportResponse {
+    public List<TransactionDetail> Transactions { get; set; }
+    public TransactionDetailSummary Summary { get; set; }
+}

--- a/EstateReportingAPI.Models/TransactionDetailSummary.cs
+++ b/EstateReportingAPI.Models/TransactionDetailSummary.cs
@@ -1,0 +1,7 @@
+﻿namespace EstateReportingAPI.Models;
+
+public class TransactionDetailSummary {
+    public Decimal TotalValue { get; set; }
+    public Decimal TotalFees { get; set; }
+    public Int32 TransactionCount { get; set; }
+}

--- a/EstateReportingAPI.Models/TransactionSummaryByMerchantRequest.cs
+++ b/EstateReportingAPI.Models/TransactionSummaryByMerchantRequest.cs
@@ -1,10 +1,9 @@
 ﻿namespace EstateReportingAPI.Models;
 
-public class TransactionDetailReportRequest
+public class TransactionSummaryByMerchantRequest
 {
     public List<Int32>? Operators { get; set; }
     public List<Int32>? Merchants { get; set; }
-    public List<Int32>? Products { get; set; }
     public DateTime StartDate { get; set; }
     public DateTime EndDate { get; set; }
 }

--- a/EstateReportingAPI.Models/TransactionSummaryByMerchantResponse.cs
+++ b/EstateReportingAPI.Models/TransactionSummaryByMerchantResponse.cs
@@ -1,0 +1,7 @@
+﻿namespace EstateReportingAPI.Models;
+
+public class TransactionSummaryByMerchantResponse
+{
+    public List<MerchantDetail> Merchants { get; set; }
+    public MerchantDetailSummary Summary { get; set; }
+}

--- a/EstateReportingAPI.Models/TransactionSummaryByOperatorRequest.cs
+++ b/EstateReportingAPI.Models/TransactionSummaryByOperatorRequest.cs
@@ -1,10 +1,9 @@
 ﻿namespace EstateReportingAPI.Models;
 
-public class TransactionDetailReportRequest
+public class TransactionSummaryByOperatorRequest
 {
     public List<Int32>? Operators { get; set; }
     public List<Int32>? Merchants { get; set; }
-    public List<Int32>? Products { get; set; }
     public DateTime StartDate { get; set; }
     public DateTime EndDate { get; set; }
 }

--- a/EstateReportingAPI.Models/TransactionSummaryByOperatorResponse.cs
+++ b/EstateReportingAPI.Models/TransactionSummaryByOperatorResponse.cs
@@ -1,0 +1,7 @@
+﻿namespace EstateReportingAPI.Models;
+
+public class TransactionSummaryByOperatorResponse
+{
+    public List<OperatorDetail> Operators { get; set; }
+    public OperatorDetailSummary Summary { get; set; }
+}

--- a/EstateReportingAPI/Bootstrapper/MediatorRegistry.cs
+++ b/EstateReportingAPI/Bootstrapper/MediatorRegistry.cs
@@ -23,6 +23,7 @@ public class MediatorRegistry : ServiceRegistry {
         this.AddSingleton<IRequestHandler<TransactionQueries.TodaysFailedSales, Result<TodaysSales>>, TransactionRequestHandler>();
         this.AddSingleton<IRequestHandler<TransactionQueries.TransactionDetailReportQuery, Result<TransactionDetailReportResponse>>, TransactionRequestHandler>();
         this.AddSingleton<IRequestHandler<TransactionQueries.TransactionSummaryByMerchantQuery, Result<TransactionSummaryByMerchantResponse>>, TransactionRequestHandler>();
+        this.AddSingleton<IRequestHandler<TransactionQueries.TransactionSummaryByOperatorQuery, Result<TransactionSummaryByOperatorResponse>>, TransactionRequestHandler>();
 
         this.AddSingleton<IRequestHandler<CalendarQueries.GetYearsQuery, Result<List<Int32>>>, CalendarRequestHandler>();
         this.AddSingleton<IRequestHandler<CalendarQueries.GetAllDatesQuery, Result<List<Calendar>>>, CalendarRequestHandler>();

--- a/EstateReportingAPI/Endpoints/TransactionEndpoints.cs
+++ b/EstateReportingAPI/Endpoints/TransactionEndpoints.cs
@@ -26,5 +26,7 @@ public static class TransactionEndpoints
             .WithStandardProduces<TransactionDetailReportResponse>();
         group.MapPost("transactionsummarybymerchantreport", TransactionHandler.TransactionSummaryByMerchantReport)
             .WithStandardProduces<TransactionSummaryByMerchantResponse>();
+        group.MapPost("transactionsummarybyoperatorreport", TransactionHandler.TransactionSummaryByOperatorReport)
+            .WithStandardProduces<TransactionSummaryByOperatorResponse>();
     }
 }

--- a/EstateReportingAPI/Handlers/TransactionHandler.cs
+++ b/EstateReportingAPI/Handlers/TransactionHandler.cs
@@ -113,4 +113,38 @@ public static class TransactionHandler {
             };
         return ResponseFactory.FromResult(result, SuccessFactory);
     }
+
+    public static async Task<IResult> TransactionSummaryByOperatorReport([FromHeader] Guid estateId,
+                                                                         [FromBody] TransactionSummaryByOperatorRequest request,
+                                                                         IMediator mediator, CancellationToken cancellationToken)
+    {
+        Models.TransactionSummaryByOperatorRequest queryRequest = new()
+        {
+            Merchants = request.Merchants,
+            Operators = request.Operators,
+            StartDate = request.StartDate,
+            EndDate = request.EndDate
+        };
+        var query = new TransactionQueries.TransactionSummaryByOperatorQuery(estateId, queryRequest);
+        var result = await mediator.Send(query, cancellationToken);
+        TransactionSummaryByOperatorResponse SuccessFactory(Models.TransactionSummaryByOperatorResponse r) =>
+            new TransactionSummaryByOperatorResponse
+            {
+                Summary = new OperatorDetailSummary { TotalOperators = r.Summary.TotalOperators, TotalCount = r.Summary.TotalCount, TotalValue = r.Summary.TotalValue, AverageValue = r.Summary.AverageValue },
+                Operators = r.Operators.Select(o => new OperatorDetail
+                    {
+                        OperatorId = o.OperatorId,
+                        OperatorName = o.OperatorName,
+                        OperatorReportingId = o.OperatorReportingId,
+                        TotalCount = o.TotalCount,
+                        TotalValue = o.TotalValue,
+                        AverageValue = o.AverageValue,
+                        AuthorisedCount = o.AuthorisedCount,
+                        DeclinedCount = o.DeclinedCount,
+                        AuthorisedPercentage = o.AuthorisedPercentage
+                    })
+                    .ToList()
+            };
+        return ResponseFactory.FromResult(result, SuccessFactory);
+    }
 }


### PR DESCRIPTION
Introduced a new report to retrieve transaction summaries grouped by operator, including new query, handler, DTOs, models, and API endpoint. Added integration tests and registered the handler. Refactored DTOs/models for clarity. Existing merchant summary and detail reports remain unchanged.

closes #428 