### PR TITLE
Add reporting IDs to contract products and fees

### DIFF
--- a/EstateReportingAPI.BusinessLogic/ReportingManager.cs
+++ b/EstateReportingAPI.BusinessLogic/ReportingManager.cs
@@ -287,6 +287,7 @@ public class ReportingManager : IReportingManager {
                                                                                   CancellationToken cancellationToken) {
         var productsQuery = context.ContractProducts.Where(cp => cp.ContractId == contractId).Select(cp => new {
             cp.ContractProductId,
+            cp.ContractProductReportingId,
             cp.ContractId,
             cp.DisplayText,
             cp.ProductName,
@@ -305,6 +306,7 @@ public class ReportingManager : IReportingManager {
         var feesQuery = context.ContractProductTransactionFees.Where(tf => productIds.Contains(tf.ContractProductId)).Select(tf => new {
             tf.CalculationType,
             tf.ContractProductTransactionFeeId,
+            tf.ContractProductTransactionFeeReportingId,
             tf.FeeType,
             tf.Value,
             tf.ContractProductId,
@@ -326,12 +328,14 @@ public class ReportingManager : IReportingManager {
             ProductName = p.ProductName,
             ProductType = p.ProductType,
             Value = p.Value,
+            ContractProductReportingId = p.ContractProductReportingId,
             TransactionFees = feesLookup[p.ContractProductId].Select(f => new ContractProductTransactionFee {
                 Description = f.Description,
                 Value = f.Value,
                 CalculationType = f.CalculationType,
                 FeeType = f.FeeType,
-                TransactionFeeId = f.ContractProductTransactionFeeId
+                TransactionFeeId = f.ContractProductTransactionFeeId,
+                ContractProductTransactionFeeReportingId = f.ContractProductTransactionFeeReportingId
             }).ToList()
         }).ToList());
     }
@@ -1362,6 +1366,7 @@ public class ReportingManager : IReportingManager {
                                                                                        string stepName) {
             var query = context.ContractProducts.Where(cp => contractIds.Contains(cp.ContractId)).Select(cp => new ContractProductData {
                 ContractProductId = cp.ContractProductId,
+                ContractProductReportingId = cp.ContractProductReportingId,
                 ContractId = cp.ContractId,
                 DisplayText = cp.DisplayText,
                 ProductName = cp.ProductName,
@@ -1377,6 +1382,7 @@ public class ReportingManager : IReportingManager {
                                                                                string stepName) {
             var query = context.ContractProductTransactionFees.Where(tf => productIds.Contains(tf.ContractProductId)).Select(tf => new ContractFeeData {
                 ContractProductTransactionFeeId = tf.ContractProductTransactionFeeId,
+                ContractProducTransactionFeeReportingId = tf.ContractProductTransactionFeeReportingId,
                 ContractProductId = tf.ContractProductId,
                 Description = tf.Description,
                 CalculationType = tf.CalculationType,
@@ -1400,6 +1406,7 @@ public class ReportingManager : IReportingManager {
                 Products = products.Where(p => p.ContractId == b.ContractId).Select(p => new Models.ContractProduct {
                     ContractId = p.ContractId,
                     ProductId = p.ContractProductId,
+                    ContractProductReportingId = p.ContractProductReportingId,
                     DisplayText = p.DisplayText,
                     ProductName = p.ProductName,
                     ProductType = p.ProductType,
@@ -1409,7 +1416,8 @@ public class ReportingManager : IReportingManager {
                         Value = f.Value,
                         CalculationType = f.CalculationType,
                         FeeType = f.FeeType,
-                        TransactionFeeId = f.ContractProductTransactionFeeId
+                        TransactionFeeId = f.ContractProductTransactionFeeId,
+                        ContractProductTransactionFeeReportingId = f.ContractProducTransactionFeeReportingId
                     }).ToList()
                 }).ToList()
             }).ToList();
@@ -1494,6 +1502,7 @@ public class ReportingManager : IReportingManager {
 
         private sealed class ContractProductData {
             public Guid ContractProductId { get; init; }
+            public int ContractProductReportingId { get; init; }
             public Guid ContractId { get; init; }
             public string? DisplayText { get; init; }
             public string? ProductName { get; init; }
@@ -1503,6 +1512,7 @@ public class ReportingManager : IReportingManager {
 
         private sealed class ContractFeeData {
             public Guid ContractProductTransactionFeeId { get; init; }
+            public int ContractProducTransactionFeeReportingId { get; init; }
             public Guid ContractProductId { get; init; }
             public string? Description { get; init; }
             public int CalculationType { get; init; }
@@ -1524,4 +1534,5 @@ public class ReportingManager : IReportingManager {
 
         #endregion
     }
+
 

--- a/EstateReportingAPI.DataTrasferObjects/Contract.cs
+++ b/EstateReportingAPI.DataTrasferObjects/Contract.cs
@@ -32,6 +32,9 @@ public class ContractProduct
 {
     [JsonProperty("contract_id")]
     public Guid ContractId { get; set; }
+    [JsonProperty("contract_product_reporting_id")]
+    public Int32 ContractProductReportingId { get; set; }
+
     [JsonProperty("product_id")]
     public Guid ProductId { get; set; }
     [JsonProperty("product_name")]
@@ -49,6 +52,9 @@ public class ContractProduct
 public class ContractProductTransactionFee {
     [JsonProperty("transaction_fee_id")] 
     public Guid TransactionFeeId { get; set; }
+    [JsonProperty("contract_product_transaction_fee_reporting_id")]
+    public Int32 ContractProductTransactionFeeReportingId { get; set; }
+
     [JsonProperty("description")] 
     public string? Description { get; set; }
     [JsonProperty("calculation_type")] 

--- a/EstateReportingAPI.IntegrationTests/ContractEndPointTests.cs
+++ b/EstateReportingAPI.IntegrationTests/ContractEndPointTests.cs
@@ -79,7 +79,10 @@ public class ContractEndPointTests : ControllerTestsBase {
         contracts.SingleOrDefault(c => c.Description == "Healthcare Centre 1 Contract").ShouldNotBeNull();
         contracts.SingleOrDefault(c => c.Description == "PataPawa PostPay Contract").ShouldNotBeNull();
         contracts.SingleOrDefault(c => c.Description == "PataPawa PrePay Contract").ShouldNotBeNull();
-
+        foreach (Contract contract in contracts) {
+            contract.Products.Any(cp => cp.ContractProductReportingId != 0).ShouldBeTrue();
+            contract.Products.ToList().ForEach(cp => cp.TransactionFees.Any(t => t.ContractProductTransactionFeeReportingId != 0).ShouldBeTrue());
+        }
     }
 
     [Fact]
@@ -111,7 +114,9 @@ public class ContractEndPointTests : ControllerTestsBase {
         Contract contract = result.Data;
         contract.ShouldNotBeNull();
         contract.Description.ShouldBe("PataPawa PrePay Contract");
-
+        contract.ContractReportingId.ShouldNotBe(0);
+        contract.Products.Any(cp => cp.ContractProductReportingId != 0).ShouldBeTrue();
+        contract.Products.ToList().ForEach(cp => cp.TransactionFees.Any(t => t.ContractProductTransactionFeeReportingId != 0).ShouldBeTrue());
     }
 
     protected override async Task ClearStandingData() {

--- a/EstateReportingAPI.Models/ContractProduct.cs
+++ b/EstateReportingAPI.Models/ContractProduct.cs
@@ -3,6 +3,7 @@
 public class ContractProduct
 {   public Guid ContractId { get; set; }
     public Guid ProductId { get; set; }
+    public Int32 ContractProductReportingId { get; set; }
     public String ProductName { get; set; }
     public String DisplayText { get; set; }
     public Int32 ProductType { get; set; }

--- a/EstateReportingAPI.Models/ContractProductTransactionFee.cs
+++ b/EstateReportingAPI.Models/ContractProductTransactionFee.cs
@@ -2,6 +2,7 @@
 
 public class ContractProductTransactionFee
 {
+    public Int32 ContractProductTransactionFeeReportingId { get; set; }
     public Guid TransactionFeeId { get; set; }
     public string? Description { get; set; }
     public Int32 CalculationType { get; set; }

--- a/EstateReportingAPI/Handlers/ContractHandler.cs
+++ b/EstateReportingAPI/Handlers/ContractHandler.cs
@@ -51,12 +51,14 @@ public static class ContractHandler {
                 ProductName = p.ProductName,
                 ProductType = p.ProductType,
                 Value = p.Value,
+                ContractProductReportingId = p.ContractProductReportingId,
                 TransactionFees = p.TransactionFees.Select(f => new DataTransferObjects.ContractProductTransactionFee {
                     Description = f.Description,
                     Value = f.Value,
                     CalculationType = f.CalculationType,
                     FeeType = f.FeeType,
-                    TransactionFeeId = f.TransactionFeeId
+                    TransactionFeeId = f.TransactionFeeId,
+                    ContractProductTransactionFeeReportingId = f.ContractProductTransactionFeeReportingId
                 }).ToList()
             }).ToList()
         }).ToList());
@@ -87,13 +89,15 @@ public static class ContractHandler {
                 ProductName = p.ProductName,
                 ProductType = p.ProductType,
                 Value = p.Value,
+                ContractProductReportingId = p.ContractProductReportingId,
                 TransactionFees = p.TransactionFees.Select(f => new DataTransferObjects.ContractProductTransactionFee
                 {
                     Description = f.Description,
                     Value = f.Value,
                     CalculationType = f.CalculationType,
                     FeeType = f.FeeType,
-                    TransactionFeeId = f.TransactionFeeId
+                    TransactionFeeId = f.TransactionFeeId,
+                    ContractProductTransactionFeeReportingId = f.ContractProductTransactionFeeReportingId
                 }).ToList()
             }).ToList()
         });


### PR DESCRIPTION
Introduced ContractProductReportingId and ContractProductTransactionFeeReportingId properties to the relevant models. Updated data mapping, JSON serialization, and query logic to ensure these reporting IDs are included throughout the data flow, from database to API response. This enables more robust reporting and traceability for contract products and their transaction fees.

closes #492 