### PR TITLE
Refactor KPI logic to use LastSale from projection state

### DIFF
--- a/EstateReportingAPI.BusinessLogic/ReportingManager.cs
+++ b/EstateReportingAPI.BusinessLogic/ReportingManager.cs
@@ -569,7 +569,7 @@ public class ReportingManager : IReportingManager {
         using ResolvedDbContext<EstateManagementContext>? resolvedContext = this.Resolver.Resolve(EstateManagementDatabaseName, request.EstateId.ToString());
         await using EstateManagementContext context = resolvedContext.Context;
 
-        var merchantsQuery = context.Merchants.Select(m => new { m.Name, m.LastSaleDate, m.LastSaleDateTime });
+        var merchantsQuery = context.MerchantBalanceProjectionState.Select(m => new { m.MerchantName, m.LastSale });
         var merchantsQueryResult = await ExecuteQuerySafeToList(merchantsQuery, cancellationToken, "Error retrieving merchants for KPI's");
         if (merchantsQueryResult.IsFailed)
             return ResultHelpers.CreateFailure(merchantsQueryResult);
@@ -578,11 +578,11 @@ public class ReportingManager : IReportingManager {
 
         DateTime now = DateTime.Now;
 
-        Int32 merchantsWithSaleInLastHour = (from m in merchants where m.LastSaleDateTime >= now.AddHours(-1) && m.LastSaleDateTime <= now select m).Count();
+        Int32 merchantsWithSaleInLastHour = (from m in merchants where m.LastSale >= now.AddHours(-1) && m.LastSale <= now select m).Count();
 
-        Int32 merchantsWithNoSaleToday = (from m in merchants where m.LastSaleDate >= now.Date.AddDays(-7) && m.LastSaleDate <= now.Date.AddDays(-1) select m).Count();
+        Int32 merchantsWithNoSaleToday = (from m in merchants where m.LastSale >= now.AddDays(-7) && m.LastSale <= now.AddDays(-1) select m).Count();
 
-        Int32 merchantsWithNoSaleInLast7Days = (from m in merchants where m.LastSaleDate <= now.Date.AddDays(-7) select m).Count();
+        Int32 merchantsWithNoSaleInLast7Days = (from m in merchants where m.LastSale <= now.AddDays(-7) select m).Count();
 
         MerchantKpi response = new() { MerchantsWithSaleInLastHour = merchantsWithSaleInLastHour, MerchantsWithNoSaleToday = merchantsWithNoSaleToday, MerchantsWithNoSaleInLast7Days = merchantsWithNoSaleInLast7Days };
 

--- a/EstateReportingAPI.IntegrationTests/DatabaseHelper.cs
+++ b/EstateReportingAPI.IntegrationTests/DatabaseHelper.cs
@@ -380,8 +380,8 @@ public class DatabaseHelper{
             EstateId = estate.EstateId,
             MerchantId = Guid.NewGuid(),
             Name = merchantName,
-            LastSaleDate = lastSaleDateTime.Date,
-            LastSaleDateTime = lastSaleDateTime
+            //LastSaleDate = lastSaleDateTime.Date,
+            //LastSaleDateTime = lastSaleDateTime
         };
 
         await this.Context.Merchants.AddAsync(merchant);
@@ -452,7 +452,8 @@ public class DatabaseHelper{
         MerchantBalanceProjectionState state = new MerchantBalanceProjectionState {
             Balance = balance,
             MerchantId = savedMerchant.MerchantId,
-            MerchantName = savedMerchant.Name
+            MerchantName = savedMerchant.Name,
+            LastSale = lastSaleDateTime,
         };
         await this.Context.MerchantBalanceProjectionState.AddAsync(state);
 


### PR DESCRIPTION
Switched merchant KPI calculations to use the LastSale property from MerchantBalanceProjectionState instead of LastSaleDate/LastSaleDateTime from Merchant. Updated test data setup to set LastSale on the projection state, centralizing last sale tracking.

closes #488 