### PR TITLE
Add TransactionNumber to transaction reporting flow

### DIFF
--- a/EstateReportingAPI.BusinessLogic/ReportingManager.cs
+++ b/EstateReportingAPI.BusinessLogic/ReportingManager.cs
@@ -705,6 +705,7 @@ public class ReportingManager : IReportingManager {
                 Value = t.TransactionAmount,
                 FeeValue = msf != null ? msf.FeeValue : 0m,
                 SettlementId = s != null ? s.SettlementId : Guid.Empty,
+                TransactionNumber = Int32.Parse(t.TransactionNumber)
             };
     }
 
@@ -737,7 +738,8 @@ public class ReportingManager : IReportingManager {
                 Status = q.Status,
                 Value = q.Value,
                 TotalFees = q.FeeValue,
-                SettlementReference = q.SettlementId.ToString()
+                SettlementReference = q.SettlementId.ToString(),
+                TransactionNumber = q.TransactionNumber
             }).ToList(),
             Summary = new TransactionDetailSummary { TransactionCount = queryResults.Count(), TotalValue = queryResults.Sum(q => q.Value), TotalFees = queryResults.Sum(q => q.FeeValue) }
         };
@@ -1466,7 +1468,8 @@ public class ReportingManager : IReportingManager {
             public decimal Value { get; init; }
             public decimal FeeValue { get; init; }
             public Guid SettlementId { get; init; }
-        }
+            public Int32 TransactionNumber { get; init; }
+    }
 
         private sealed class OperatorTransactionData {
             public Guid MerchantId { get; init; }

--- a/EstateReportingAPI.DataTrasferObjects/TransactionDetail.cs
+++ b/EstateReportingAPI.DataTrasferObjects/TransactionDetail.cs
@@ -37,4 +37,6 @@ public class TransactionDetail
     public Decimal TotalFees { get; set; }
     [JsonProperty("settlement_reference")]
     public String SettlementReference { get; set; }
+    [JsonProperty("transaction_number")]
+    public Int32 TransactionNumber { get; set; }
 }

--- a/EstateReportingAPI.IntegrationTests/TransactionsEndpointTests.cs
+++ b/EstateReportingAPI.IntegrationTests/TransactionsEndpointTests.cs
@@ -393,6 +393,7 @@ public class TransactionsEndpointTests : ControllerTestsBase {
         foreach (Transaction transaction in transactions) {
             var foundTxn = transactionDetailReportResponse.Transactions.SingleOrDefault(t => t.Id == transaction.TransactionId);
             foundTxn.ShouldNotBeNull(transaction.TransactionId.ToString());
+            foundTxn.TransactionNumber.ShouldNotBe(0);
         }
     }
 

--- a/EstateReportingAPI.Models/TransactionDetail.cs
+++ b/EstateReportingAPI.Models/TransactionDetail.cs
@@ -17,4 +17,5 @@ public class TransactionDetail {
     public Decimal Value { get; set; }
     public Decimal TotalFees { get; set; }
     public String SettlementReference { get; set; }
+    public Int32 TransactionNumber { get; set; }
 }

--- a/EstateReportingAPI/Handlers/TransactionHandler.cs
+++ b/EstateReportingAPI/Handlers/TransactionHandler.cs
@@ -103,7 +103,8 @@ public static class TransactionHandler {
                         OperatorId = t.OperatorId,
                         MerchantReportingId = t.MerchantReportingId,
                         ProductId = t.ProductId,
-                        ProductReportingId = t.ProductReportingId
+                        ProductReportingId = t.ProductReportingId,
+                        TransactionNumber = t.TransactionNumber
 
                 })
                     .ToList()


### PR DESCRIPTION
Introduce TransactionNumber (Int32) to TransactionDetail and related query/result models. Update mapping logic and JSON serialization to include this property. Add tests to ensure TransactionNumber is set for each transaction.

closes #507 