### PR TITLE
Make Sentry options configurable via app settings

### DIFF
--- a/EstateReportingAPI/Program.cs
+++ b/EstateReportingAPI/Program.cs
@@ -86,7 +86,8 @@ public class Program{
                                                                  o.Dsn = builtConfig["SentryConfiguration:Dsn"];
                                                                  o.SendDefaultPii = true;
                                                                  o.MaxRequestBodySize = RequestSize.Always;
-                                                                 o.CaptureBlockingCalls = true;
+                                                                 o.CaptureBlockingCalls = ConfigurationReader.GetValueOrDefault("SentryConfiguration", "CaptureBlockingCalls", false);
+                                                                 o.IncludeActivityData = ConfigurationReader.GetValueOrDefault("SentryConfiguration", "IncludeActivityData", false);
                                                                  o.Release = Assembly.GetExecutingAssembly().GetName().Version?.ToString() ?? "unknown";
                                                              });
                                                          }


### PR DESCRIPTION
Updated Sentry setup to read CaptureBlockingCalls and IncludeActivityData from configuration, defaulting both to false if not set. This allows dynamic control of these options without code changes.

closes #518 