### PR TITLE
Improve null/default check after async query result

### DIFF
--- a/EstateReportingAPI.BusinessLogic/ReportingManager.cs
+++ b/EstateReportingAPI.BusinessLogic/ReportingManager.cs
@@ -108,7 +108,7 @@ public class ReportingManager : IReportingManager {
         try {
             T item = await query.SingleOrDefaultAsync(cancellationToken);
 
-            if (item == null)
+            if (EqualityComparer<T>.Default.Equals(item, default(T)))
                 return Result.NotFound(contextMessage);
 
             return Result.Success(item);


### PR DESCRIPTION
Updated the logic for detecting "not found" results after asynchronous queries by replacing item == null with EqualityComparer<T>.Default.Equals(item, default(T)). This ensures correct handling for both reference and value types when checking for default values.

closes #512 