### PR TITLE
Remove default value for cancellationToken in interceptor

### DIFF
--- a/EstateReportingAPI.BusinessLogic/QueryTimingInterceptor.cs
+++ b/EstateReportingAPI.BusinessLogic/QueryTimingInterceptor.cs
@@ -37,7 +37,7 @@ public class QueryTimingInterceptor : DbCommandInterceptor {
     public override async ValueTask<DbDataReader> ReaderExecutedAsync(DbCommand command,
                                                                       CommandExecutedEventData eventData,
                                                                       DbDataReader result,
-                                                                      CancellationToken cancellationToken = new CancellationToken()) {
+                                                                      CancellationToken cancellationToken) {
         LogIfRequired(command, eventData);
 
         return result;


### PR DESCRIPTION
The ReaderExecutedAsync method in QueryTimingInterceptor no longer provides a default value for the cancellationToken parameter. Callers must now explicitly supply a CancellationToken when invoking this method.

closes #521 