### PR TITLE
Adopt Central Package Management for NuGet dependencies

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,0 +1,3 @@
+<Project>
+  <Import Project="Directory.Packages.props" Condition="Exists('Directory.Packages.props')" />
+</Project>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,0 +1,55 @@
+<Project>
+  <PropertyGroup>
+    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Tools" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
+    <PackageVersion Include="Moq" Version="4.20.72" />
+    <PackageVersion Include="Shouldly" Version="4.3.0" />
+    <PackageVersion Include="Swashbuckle.AspNetCore" Version="10.2.1" />
+    <PackageVersion Include="TransactionProcessor.Database" Version="2026.5.2" />
+    <PackageVersion Include="xunit.v3" Version="3.2.2" />
+    <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />
+    <PackageVersion Include="coverlet.msbuild" Version="10.0.1" />
+    <PackageVersion Include="ClientProxyBase" Version="2026.5.7" />
+    <PackageVersion Include="Shared.Results" Version="2026.5.7" />
+    <PackageVersion Include="MediatR" Version="14.1.0" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.DynamicLinq" Version="10.7.2" />
+    <PackageVersion Include="Microsoft.AspNetCore.OpenApi" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.23.0" />
+    <PackageVersion Include="Shared.Results.Web" Version="2026.5.7" />
+    <PackageVersion Include="OpenIddict.Validation.AspNetCore" Version="7.5.0" />
+    <PackageVersion Include="OpenIddict.Validation.SystemNetHttp" Version="7.5.0" />
+    <PackageVersion Include="Lamar" Version="16.0.0" />
+    <PackageVersion Include="Lamar.Microsoft.DependencyInjection" Version="16.0.0" />
+    <PackageVersion Include="NLog.Extensions.Logging" Version="6.1.3" />
+    <PackageVersion Include="Shared" Version="2026.5.7" />
+    <PackageVersion Include="AspNetCore.HealthChecks.SqlServer" Version="9.0.0" />
+    <PackageVersion Include="AspNetCore.HealthChecks.UI.Client" Version="9.0.0" />
+    <PackageVersion Include="AspNetCore.HealthChecks.UI.InMemory.Storage" Version="9.0.0" />
+    <PackageVersion Include="AspNetCore.HealthChecks.Uris" Version="9.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting.WindowsServices" Version="10.0.9" />
+    <PackageVersion Include="Swashbuckle.AspNetCore.Annotations" Version="10.2.1" />
+    <PackageVersion Include="Swashbuckle.AspNetCore.Filters" Version="10.0.1" />
+    <PackageVersion Include="Swashbuckle.AspNetCore.Swagger" Version="10.2.1" />
+    <PackageVersion Include="Swashbuckle.AspNetCore.SwaggerGen" Version="10.2.1" />
+    <PackageVersion Include="Swashbuckle.AspNetCore.SwaggerUI" Version="10.2.1" />
+    <PackageVersion Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.9" />
+    <PackageVersion Include="Sentry.AspNetCore" Version="6.6.0" />
+    <PackageVersion Include="Shared.Logger" Version="2026.5.7" />
+    <PackageVersion Include="Shared.IntegrationTesting" Version="2026.5.7" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.8" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.8" />
+    <PackageVersion Include="coverlet.collector" Version="3.2.0" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.9" />
+    <PackageVersion Include="Ductus.FluentDocker" Version="2.85.0" />
+    <PackageVersion Include="NLog" Version="6.1.3" />
+    <PackageVersion Include="SecurityService.Client" Version="2026.5.1" />
+  </ItemGroup>
+</Project>

--- a/EstateReportingAPI.BusinessLogic.UnitTests/EstateReportingAPI.BusinessLogic.UnitTests.csproj
+++ b/EstateReportingAPI.BusinessLogic.UnitTests/EstateReportingAPI.BusinessLogic.UnitTests.csproj
@@ -10,20 +10,20 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="7.0.11">
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="7.0.11" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.0" />
-    <PackageReference Include="Moq" Version="4.20.69" />
-    <PackageReference Include="Shouldly" Version="4.2.1" />
-    <PackageReference Include="xunit" Version="2.4.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="Moq" />
+    <PackageReference Include="Shouldly" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="3.2.0">
+    <PackageReference Include="coverlet.collector">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/EstateReportingAPI.BusinessLogic/EstateReportingAPI.BusinessLogic.csproj
+++ b/EstateReportingAPI.BusinessLogic/EstateReportingAPI.BusinessLogic.csproj
@@ -7,11 +7,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="MediatR" Version="14.1.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.DynamicLinq" Version="10.7.2" />
-    <PackageReference Include="Shared" Version="2026.5.6" />
-    <PackageReference Include="Shared.Results" Version="2026.5.6" />
-    <PackageReference Include="TransactionProcessor.Database" Version="2026.5.2-build358" />
+    <PackageReference Include="MediatR" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.DynamicLinq" />
+    <PackageReference Include="Shared" />
+    <PackageReference Include="Shared.Results" />
+    <PackageReference Include="TransactionProcessor.Database" />
   </ItemGroup>
 
   <ItemGroup>

--- a/EstateReportingAPI.Client/EstateReportingAPI.Client.csproj
+++ b/EstateReportingAPI.Client/EstateReportingAPI.Client.csproj
@@ -7,8 +7,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="ClientProxyBase" Version="2026.5.6" />
-    <PackageReference Include="Shared.Results" Version="2026.5.6" />
+	<PackageReference Include="ClientProxyBase" />
+	<PackageReference Include="Shared.Results" />
   </ItemGroup>
 
   <ItemGroup>

--- a/EstateReportingAPI.IntegrationTests/ControllerTestsBase.cs
+++ b/EstateReportingAPI.IntegrationTests/ControllerTestsBase.cs
@@ -19,7 +19,6 @@ using Shared.IntegrationTesting;
 using Shared.Logger;
 using Shouldly;
 using Xunit;
-using Xunit.Abstractions;
 
 public abstract class ControllerTestsBase : IAsyncLifetime
 {
@@ -30,7 +29,7 @@ public abstract class ControllerTestsBase : IAsyncLifetime
     protected DatabaseHelper helper;
     protected ITestOutputHelper TestOutputHelper;
     protected DockerHelper DockerHelper;
-    public virtual async Task InitializeAsync()
+    public virtual async ValueTask InitializeAsync()
     {
         this.TestId = Guid.NewGuid();
         String scenarioName = this.TestId.ToString();
@@ -55,7 +54,7 @@ public abstract class ControllerTestsBase : IAsyncLifetime
         await this.SetupStandingData();
     }
 
-    public virtual async Task DisposeAsync()
+    public virtual async ValueTask DisposeAsync()
     {
         await this.DockerHelper.StopContainersForScenarioRun(DockerServices.None);
     }

--- a/EstateReportingAPI.IntegrationTests/EstateReportingAPI.IntegrationTests.csproj
+++ b/EstateReportingAPI.IntegrationTests/EstateReportingAPI.IntegrationTests.csproj
@@ -7,30 +7,30 @@
   </PropertyGroup>
 
   <ItemGroup>
-	  <PackageReference Include="Swashbuckle.AspNetCore" Version="10.1.5" />
-	  <PackageReference Include="TransactionProcessor.Database" Version="2026.5.2-build358" />
-	  <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.4" />
-	  <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.8" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
-    <PackageReference Include="xunit" Version="2.9.3" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
+    <PackageReference Include="Swashbuckle.AspNetCore" />
+      <PackageReference Include="TransactionProcessor.Database" />
+      <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" />
+      <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="xunit.v3" />
+    <PackageReference Include="xunit.runner.visualstudio">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-	  <PackageReference Include="coverlet.msbuild" Version="8.0.0">
+    <PackageReference Include="coverlet.msbuild">
 		  <PrivateAssets>all</PrivateAssets>
 		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 	  </PackageReference>
-    <PackageReference Include="Shouldly" Version="4.3.0" />
-	  <PackageReference Include="Shared" Version="2026.5.6" />
-	  <PackageReference Include="Shared.Logger" Version="2026.5.6" />
-    <PackageReference Include="Shared.IntegrationTesting" Version="2026.5.6" />
-    <PackageReference Include="Ductus.FluentDocker" Version="2.85.0" />
-	  <PackageReference Include="NLog" Version="6.1.1" />
-    <PackageReference Include="NLog.Extensions.Logging" Version="6.1.2" />
-    <PackageReference Include="SecurityService.Client" Version="2026.4.3-build157" />
-	  <PackageReference Include="Lamar" Version="15.0.1" />
-	  <PackageReference Include="Lamar.Microsoft.DependencyInjection" Version="15.0.1" />
+    <PackageReference Include="Shouldly" />
+      <PackageReference Include="Shared" />
+      <PackageReference Include="Shared.Logger" />
+    <PackageReference Include="Shared.IntegrationTesting" />
+    <PackageReference Include="Ductus.FluentDocker" />
+    <PackageReference Include="NLog" />
+      <PackageReference Include="NLog.Extensions.Logging" />
+      <PackageReference Include="SecurityService.Client" />
+      <PackageReference Include="Lamar" />
+      <PackageReference Include="Lamar.Microsoft.DependencyInjection" />
 
   </ItemGroup>
 

--- a/EstateReportingAPI.IntegrationTests/FileImportLogsEndpointTests.cs
+++ b/EstateReportingAPI.IntegrationTests/FileImportLogsEndpointTests.cs
@@ -12,7 +12,6 @@ using Microsoft.EntityFrameworkCore;
 using Shouldly;
 using SimpleResults;
 using Xunit;
-using Xunit.Abstractions;
 
 namespace EstateReportingAPI.IntegrationTests
 {

--- a/EstateReportingAPI.IntegrationTests/SettlmentsEndpointTests.cs
+++ b/EstateReportingAPI.IntegrationTests/SettlmentsEndpointTests.cs
@@ -6,7 +6,6 @@ using System.Threading;
 using System.Threading.Tasks;
 using Shouldly;
 using Xunit;
-using Xunit.Abstractions;
 
 namespace EstateReportingAPI.IntegrationTests;
 

--- a/EstateReportingAPI.IntegrationTests/TransactionsEndpointTests.cs
+++ b/EstateReportingAPI.IntegrationTests/TransactionsEndpointTests.cs
@@ -10,7 +10,6 @@ using Shouldly;
 using SimpleResults;
 using TransactionProcessor.Database.Entities;
 using Xunit;
-using Xunit.Abstractions;
 
 namespace EstateReportingAPI.IntegrationTests;
 

--- a/EstateReportingAPI.Testing/EstateReportingAPI.csproj
+++ b/EstateReportingAPI.Testing/EstateReportingAPI.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="7.0.7" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" />
   </ItemGroup>
 
 

--- a/EstateReportingAPI.Tests/EstateReportingAPI.Tests.csproj
+++ b/EstateReportingAPI.Tests/EstateReportingAPI.Tests.csproj
@@ -7,26 +7,26 @@
   </PropertyGroup>
 
   <ItemGroup>
-      <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.8" />
-	  <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.8" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.8" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.8" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.8" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="10.0.8">
+      <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
+      <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools">
 	    <PrivateAssets>all</PrivateAssets>
 	    <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
-    <PackageReference Include="Moq" Version="4.20.72" />
-    <PackageReference Include="Shouldly" Version="4.3.0" />
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="10.1.5" />
-    <PackageReference Include="TransactionProcessor.Database" Version="2026.5.2-build358" />
-    <PackageReference Include="xunit" Version="2.9.3" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="Moq" />
+    <PackageReference Include="Shouldly" />
+    <PackageReference Include="Swashbuckle.AspNetCore" />
+    <PackageReference Include="TransactionProcessor.Database" />
+    <PackageReference Include="xunit.v3" />
+    <PackageReference Include="xunit.runner.visualstudio">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.msbuild" Version="8.0.0">
+    <PackageReference Include="coverlet.msbuild">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/EstateReportingAPI.sln
+++ b/EstateReportingAPI.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 17
-VisualStudioVersion = 17.8.34004.107
+# Visual Studio Version 18
+VisualStudioVersion = 18.7.11903.348
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "EstateReportingAPI", "EstateReportingAPI\EstateReportingAPI.csproj", "{8E6ED1E8-9776-49F3-ADEB-17A03318E136}"
 EndProject
@@ -20,6 +20,8 @@ EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "EstateReportingAPI.Models", "EstateReportingAPI.Models\EstateReportingAPI.Models.csproj", "{B3BE4743-D80E-4247-BAC0-1224D5A6D472}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "EstateReportingAPI.IntegrationTests", "EstateReportingAPI.IntegrationTests\EstateReportingAPI.IntegrationTests.csproj", "{85555B3A-FC04-4291-B0CB-F0835AC23D3E}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{A296632F-ABDB-4D3E-9351-51346C70C08A}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/EstateReportingAPI/Dockerfile
+++ b/EstateReportingAPI/Dockerfile
@@ -5,6 +5,8 @@ FROM mcr.microsoft.com/dotnet/sdk:10.0 AS build
 WORKDIR /src
 COPY ["EstateReportingAPI/NuGet.Config", "."]
 COPY ["EstateReportingAPI/EstateReportingAPI.csproj", "EstateReportingAPI/"]
+COPY ["Directory.Packages.props", "."]
+COPY . .
 RUN dotnet restore "EstateReportingAPI/EstateReportingAPI.csproj"
 COPY . .
 WORKDIR "/src/EstateReportingAPI"

--- a/EstateReportingAPI/Dockerfilewindows
+++ b/EstateReportingAPI/Dockerfilewindows
@@ -6,6 +6,8 @@ FROM mcr.microsoft.com/dotnet/sdk:10.0-windowsservercore-ltsc2022 AS build
 WORKDIR /src
 COPY ["EstateReportingAPI/NuGet.Config", "."]
 COPY ["EstateReportingAPI/EstateReportingAPI.csproj", "EstateReportingAPI/"]
+COPY ["Directory.Packages.props", "."]
+COPY . .
 RUN dotnet restore "EstateReportingAPI/EstateReportingAPI.csproj"
 COPY . .
 WORKDIR "/src/EstateReportingAPI"

--- a/EstateReportingAPI/EstateReportingAPI.csproj
+++ b/EstateReportingAPI/EstateReportingAPI.csproj
@@ -9,35 +9,35 @@
   </PropertyGroup>
 
   <ItemGroup>
-	  
-    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.4" />
-    <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.23.0" />
-    <PackageReference Include="Shared.Results" Version="2026.5.6" />
-    <PackageReference Include="Shared.Results.Web" Version="2026.5.6" />
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="10.0.1" />
+
+	<PackageReference Include="Microsoft.AspNetCore.OpenApi" />
+	<PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Condition="'$(OS)' == 'Windows_NT'" />
+	<PackageReference Include="Shared.Results" />
+	<PackageReference Include="Shared.Results.Web" />
+	<PackageReference Include="Swashbuckle.AspNetCore" />
   </ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="OpenIddict.Validation.AspNetCore" Version="7.4.0" />
-		<PackageReference Include="OpenIddict.Validation.SystemNetHttp" Version="7.4.0" />
-		<PackageReference Include="Lamar" Version="15.0.1" />
-		<PackageReference Include="Lamar.Microsoft.DependencyInjection" Version="15.0.1" />
-		<PackageReference Include="NLog.Extensions.Logging" Version="6.1.2" />
-		<PackageReference Include="Shared" Version="2026.5.6" />
-		<PackageReference Include="AspNetCore.HealthChecks.SqlServer" Version="9.0.0" />
-		<PackageReference Include="AspNetCore.HealthChecks.UI.Client" Version="9.0.0" />
-		<PackageReference Include="AspNetCore.HealthChecks.UI.InMemory.Storage" Version="9.0.0" />
-		<PackageReference Include="AspNetCore.HealthChecks.Uris" Version="9.0.0" />
-		<PackageReference Include="Microsoft.Extensions.Hosting.WindowsServices" Version="10.0.4" />
-		<PackageReference Include="Swashbuckle.AspNetCore" Version="10.1.5" />
-		<PackageReference Include="Swashbuckle.AspNetCore.Annotations" Version="10.1.5" />
-		<PackageReference Include="Swashbuckle.AspNetCore.Filters" Version="10.0.1" />
-		<PackageReference Include="Swashbuckle.AspNetCore.Swagger" Version="10.1.5" />
-		<PackageReference Include="Swashbuckle.AspNetCore.SwaggerGen" Version="10.1.5" />
-		<PackageReference Include="Swashbuckle.AspNetCore.SwaggerUI" Version="10.1.5" />
-		<PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.4" />
-		<PackageReference Include="TransactionProcessor.Database" Version="2026.5.2-build358" />
-		<PackageReference Include="Sentry.AspNetCore" Version="6.2.0" />
+		<PackageReference Include="OpenIddict.Validation.AspNetCore" />
+		<PackageReference Include="OpenIddict.Validation.SystemNetHttp" />
+		<PackageReference Include="Lamar" />
+		<PackageReference Include="Lamar.Microsoft.DependencyInjection" />
+		<PackageReference Include="NLog.Extensions.Logging" />
+		<PackageReference Include="Shared" />
+		<PackageReference Include="AspNetCore.HealthChecks.SqlServer" />
+		<PackageReference Include="AspNetCore.HealthChecks.UI.Client" />
+		<PackageReference Include="AspNetCore.HealthChecks.UI.InMemory.Storage" />
+		<PackageReference Include="AspNetCore.HealthChecks.Uris" />
+		<PackageReference Include="Microsoft.Extensions.Hosting.WindowsServices" />
+		<PackageReference Include="Swashbuckle.AspNetCore" />
+		<PackageReference Include="Swashbuckle.AspNetCore.Annotations" />
+		<PackageReference Include="Swashbuckle.AspNetCore.Filters" />
+		<PackageReference Include="Swashbuckle.AspNetCore.Swagger" />
+		<PackageReference Include="Swashbuckle.AspNetCore.SwaggerGen" />
+		<PackageReference Include="Swashbuckle.AspNetCore.SwaggerUI" />
+		<PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" />
+		<PackageReference Include="TransactionProcessor.Database" />
+		<PackageReference Include="Sentry.AspNetCore" />
 	</ItemGroup>
 
 	<ItemGroup>


### PR DESCRIPTION
Introduce Directory.Packages.props for CPM and update Directory.Build.props to import it. Remove explicit version numbers from all .csproj files, centralizing dependency versions. Update Dockerfiles to copy Directory.Packages.props. Refactor ControllerTestsBase.cs to use ValueTask for async methods and clean up unused usings. Update solution file for latest Visual Studio and add Solution Items folder.

closes #556 
closes #557 